### PR TITLE
feat: Make transcription not block the UI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,16 +170,16 @@ joplin.plugins.register({
           // Update the transcription note with the actual result
           try {
             await joplin.data.put(["notes", transcriptionNote.id], null, {
-            body: result,
-          });          
-        } catch (updateError) {
-          joplin.views.dialogs.showToast({
-            message: `Failed to update transcription note. Did you delete or move the note during transcription?`,
-            type: ToastType.Error,
-          });
+              body: result,
+            });
+          } catch (updateError) {
+            joplin.views.dialogs.showToast({
+              message: `Failed to update transcription note. Did you delete or move the note during transcription?`,
+              type: ToastType.Error,
+            });
 
-          console.error("Failed to update transcription note:", updateError);
-        }
+            console.error("Failed to update transcription note:", updateError);
+          }
           joplin.views.dialogs.showToast({
             message: `Transcription complete! The result is in the note "${transcriptionTitle}".`,
             type: ToastType.Success,


### PR DESCRIPTION
## Description

This PR improves the workflow by replacing alerts with toast popups and moving the transcription output to a new note. This allows users to continue editing their other notes while the transcript is being generated, and users can even start multiple transcriptions at the same time.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Updated UI alerts to toast popups to make them non-blocking
- Moved transcription result to new file

## Testing

- [ ] Tested with OpenAI Whisper provider
- [x] Tested with Google Gemini provider
- [x] Tested with MP3
- [x] Manually tested in Joplin
- [ ] Added/updated unit tests
- [x] All existing tests pass

## Checklist

- [x] My code follows the existing code style
- [x] I have commented my code where necessary
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly